### PR TITLE
fix: correct lambda typo in block diagonalization theorem

### DIFF
--- a/src/cplx-eigenvals.xml
+++ b/src/cplx-eigenvals.xml
@@ -1340,7 +1340,7 @@ A-\frac{4+3i}5I_3 =
           <ul>
             <li>
               The matrix <m>B</m> is <term>block diagonal</term>, where the blocks are <m>1\times 1</m> blocks containing the real eigenvalues (with their multiplicities), or <m>2\times 2</m> blocks containing the matrices
-              <me>\mat{\Re(\lambda) \Im(\lambda); -\Im(\lambda) \Re(\Lambda)}</me>
+              <me>\mat{\Re(\lambda) \Im(\lambda); -\Im(\lambda) \Re(\lambda)}</me>
               for each non-real eigenvalue <m>\lambda</m> (with multiplicity).
             </li>
             <li>


### PR DESCRIPTION
## Summary
- fix the Block Diagonalization Theorem matrix entry typo in `src/cplx-eigenvals.xml`
- replace `\Re(\Lambda)` with `\Re(\lambda)` so the 2x2 block matches the stated non-real eigenvalue form

Fixes #40

## Testing
- verified the exact XML entry was corrected
- verified the incorrect `\Re(\Lambda)` form no longer appears in the file

## Notes
- docs/source-only change
- no competing PRs were open for this issue when checked
